### PR TITLE
Don't show empty ul.stats

### DIFF
--- a/layouts/post/footer-category.html
+++ b/layouts/post/footer-category.html
@@ -1,44 +1,44 @@
-<ul class="stats">
-    {{ if isset .Params "categories" }}
-        {{ $categoryCount := (len .Params.categories) }}
+{{ if isset .Params "categories" }}
+    <ul class="stats">
+            {{ $categoryCount := (len .Params.categories) }}
 
-        <!--
-            Set the title before displaying the categories associated with this post.
-            The title will use the variables from the Categories menu set in the Config.
-            If the Categories menu was not set then use the default values instead.
-        -->
-        {{ if ge $categoryCount 1 }}
-            <li>
-                {{ $categoryMenu := (where .Site.Menus.main "Name" "Categories") }}
-                {{ if ne (len $categoryMenu) 0 }}
-                    {{ $categoryMenu := index $categoryMenu 0 }}
+            <!--
+                Set the title before displaying the categories associated with this post.
+                The title will use the variables from the Categories menu set in the Config.
+                If the Categories menu was not set then use the default values instead.
+            -->
+            {{ if ge $categoryCount 1 }}
+                <li>
+                    {{ $categoryMenu := (where .Site.Menus.main "Name" "Categories") }}
+                    {{ if ne (len $categoryMenu) 0 }}
+                        {{ $categoryMenu := index $categoryMenu 0 }}
 
-                    {{ $.Scratch.Set "categoryUrl" $categoryMenu.URL }}
+                        {{ $.Scratch.Set "categoryUrl" $categoryMenu.URL }}
 
-                    {{ with $categoryMenu.Identifier }}
-                        <i class="{{ . }}">&nbsp;</i>
-                    {{ end }}
+                        {{ with $categoryMenu.Identifier }}
+                            <i class="{{ . }}">&nbsp;</i>
+                        {{ end }}
 
-                    {{ if gt $categoryCount 1 }}
-                        {{ $categoryMenu.Name }}
+                        {{ if gt $categoryCount 1 }}
+                            {{ $categoryMenu.Name }}
+                        {{ else }}
+                            {{ $categoryMenu.Name | singularize }}
+                        {{ end }}
                     {{ else }}
-                        {{ $categoryMenu.Name | singularize }}
-                    {{ end }}
-                {{ else }}
-                    {{ $.Scratch.Set "categoryUrl" "/categories/" }}
+                        {{ $.Scratch.Set "categoryUrl" "/categories/" }}
 
-                    {{ if gt $categoryCount 1 }}
-                        Categories
-                    {{ else }}
-                        Category
+                        {{ if gt $categoryCount 1 }}
+                            Categories
+                        {{ else }}
+                            Category
+                        {{ end }}
                     {{ end }}
-                {{ end }}
-            </li>
+                </li>
+            {{ end }}
+
+        <!-- Display the categories associated with this post -->
+        {{ range .Params.categories }}
+            <li><a href='{{ add ($.Scratch.Get "categoryUrl") . | urlize }}'>{{ . }}</a></li>
         {{ end }}
-    {{ end }}
-
-    <!-- Display the categories associated with this post -->
-    {{ range .Params.categories }}
-        <li><a href='{{ add ($.Scratch.Get "categoryUrl") . | urlize }}'>{{ . }}</a></li>
-    {{ end }}
-</ul>
+    </ul>
+{{ end }}


### PR DESCRIPTION
Move the conditional check for Params:categories outside of the
ul definition so that the element is completely hidden (along with
its unnecessary pre/post whitespace) if there are no categories.
