### PR TITLE
Remove refs to deprecated orderByPublishDate

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -4,14 +4,7 @@
     {{ partial "navbar" . }}
     <!-- Main -->
     <div id="main">
-        <!-- Please note that the param orderByPublishDate is no longer being used
-             since the pagination is not what is expected. Use at your own risk! -->
-        {{ if .Site.Params.orderByPublishDate }}
-            {{ $paginator := .Paginate (where .Data.Pages.ByPublishDate.Reverse "Type" "post") }}
-        {{ else }}
-            {{ $paginator := .Paginate (where .Site.Pages "Type" "post") }}
-        {{ end }}
-
+        {{ $paginator := .Paginate .Data.Pages }}
         {{ range .Paginator.Pages }}
             {{ .Render "content-list" }}
         {{ end }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -36,11 +36,7 @@
                 <header>
                     <h3>Recent Posts</h3>
                 </header>
-                {{ if .Site.Params.orderByPublishDate }}
-                    {{ $.Scratch.Set "recentPosts" .Site.Pages.ByPublishDate.Reverse }}
-                {{ else }}
-                    {{ $.Scratch.Set "recentPosts" .Site.Pages }}
-                {{ end }}
+                {{ $.Scratch.Set "recentPosts" .Site.Pages }}
 
                 {{ with .Site.Params.postAmount.sidebar }}
                     {{ $.Scratch.Set "postLimit" . }}
@@ -53,11 +49,7 @@
                         <article>
                             <header>
                                 <h3><a href="{{ .Permalink }}">{{ .Title }}</a></h3>
-                                {{ if .Site.Params.orderByPublishDate }}
-                                    {{ $.Scratch.Set "dateType" .PublishDate }}
-                                {{ else }}
-                                    {{ $.Scratch.Set "dateType" .Date }}
-                                {{ end }}
+                                {{ $.Scratch.Set "dateType" .Date }}
                                 <time class="published" datetime=
                                     '{{ ($.Scratch.Get "dateType").Format "2006-01-02" }}'>
                                     {{ ($.Scratch.Get "dateType").Format "January 2, 2006" }}</time>

--- a/layouts/post/header.html
+++ b/layouts/post/header.html
@@ -11,11 +11,7 @@
         {{ end }}
     </div>
     <div class="meta">
-        {{ if .Site.Params.orderByPublishDate }}
-            {{ $.Scratch.Set "dateType" .PublishDate }}
-        {{ else }}
-            {{ $.Scratch.Set "dateType" .Date }}
-        {{ end }}
+        {{ $.Scratch.Set "dateType" .Date }}
 
         <time class="published"
             datetime='{{ ($.Scratch.Get "dateType").Format "2006-01-02" }}'>


### PR DESCRIPTION
If orderByPublishDate is no longer being used, it should probably just be removed.
