### PR TITLE
Create a way to hide recent posts

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -59,8 +59,9 @@ googleAnalytics = ""
     width     = ""
     alt       = "Hugo Future Imperfect"
 
-# Adjust the amount of recent posts on the sidebar.
-# This is optional. The default value 5 will be used
+# Adjust the number of recent posts on the sidebar.
+# Set to -1 to disable recent posts.
+# This is optional. The default value 5 will be used.
 [params.postAmount]
     sidebar = 2
 

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -69,6 +69,7 @@
         </section>
 
     <!-- Recent Posts -->
+    {{ if ge .Site.Params.postAmount.sidebar 0 }}
         <section>
             <ul class="links">
                 <header>
@@ -87,6 +88,7 @@
                 {{ end }}
             </ul>
         </section>
+    {{ end }}
 
     <!-- Actions -->
         <!--

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -31,6 +31,7 @@
         </section>
 
     <!-- Posts List -->
+    {{ if ge .Site.Params.postAmount.sidebar 0 }}
         <section id="recent-posts">
             <ul class="posts">
                 <header>
@@ -81,6 +82,7 @@
                 {{ end }}
             </ul>
         </section>
+    {{ end }}
 
     <!-- This if statement only applies if someone goes to the /categories url -->
     <!-- Otherwise this section is shown for all other links -->


### PR DESCRIPTION
Hide recent posts if the "number to show" is set to a negative value.
This allows the current "default" behavior but also gives a way to
disable recent posts without adding a new boolean show/hide config
variable.
