### PR TITLE
Ensure there is a trailing '/' in the categoryURL

### DIFF
--- a/layouts/post/footer-category.html
+++ b/layouts/post/footer-category.html
@@ -15,6 +15,11 @@
 
                     {{ $.Scratch.Set "categoryUrl" $categoryMenu.URL }}
 
+                    <!-- Ensure that there is a trailing '/' in the category Url -->
+                    {{ if ne (substr ($.Scratch.Get "categoryUrl") (sub (len ($.Scratch.Get "categoryUrl")) 1)) "/" }}
+                        {{ $.Scratch.Set "categoryUrl" (add ($.Scratch.Get "categoryUrl") "/") }}
+                    {{ end }}
+
                     {{ with $categoryMenu.Identifier }}
                         <i class="{{ . }}">&nbsp;</i>
                     {{ end }}


### PR DESCRIPTION
There needs to be a trailing '/' in the categoryURL before appending the category. Without this the template produces invalid urls for the category links in the footer of the post if the user has defined a menu item named "Categories" without a trailing slash (as in the example page).
