### PR TITLE
Change references to resources to use relURL

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -16,18 +16,18 @@
         <!-- If the value "default" is passed into the param then we will first
              load the standard js files associated with the theme -->
         {{ if or (in ($.Scratch.Get "jsFiles") "default") (eq ($.Scratch.Get "jsFiles") false) }}
-            <script src="/js/jquery.min.js"></script>
-            <script src="/js/skel.min.js"></script>
-            <script src="/js/util.js"></script>
-            <script src="/js/main.js"></script>
-            <script src="/js/backToTop.js"></script>
-            <script src="/js/highlight.pack.js"></script>
+            <script src="{{ "/js/jquery.min.js" | relURL }}"></script>
+            <script src="{{ "/js/skel.min.js" | relURL }}"></script>
+            <script src="{{ "/js/util.js" | relURL }}"></script>
+            <script src="{{ "/js/main.js" | relURL }}"></script>
+            <script src="{{ "/js/backToTop.js" | relURL }}"></script>
+            <script src="{{ "/js/highlight.pack.js" | relURL }}"></script>
         {{ end }}
 
         {{ if ne ($.Scratch.Get "jsFiles") false }}
             {{ range $.Scratch.Get "jsFiles" }}
                 {{ if ne . "default" }}
-                    <script src="{{ . }}"></script>
+                    <script src="{{ . | relURL }}"></script>
                 {{ end }}
             {{ end }}
         {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -37,7 +37,7 @@
         {{ template "_internal/schema.html" . }}
         {{ template "_internal/google_news.html" . }}
 
-        <!--[if lte IE 8]><script src="/js/ie/html5shiv.js"></script><![endif]-->
+        <!--[if lte IE 8]><script src="{{ "/js/ie/html5shiv.js" | relURL }}"></script><![endif]-->
 
         <!-- Keeping the deprecated param, minifiedFilesCSS, for now. The new param
              that replaces this is customCSS. Utilizing a scratch variable cssFiles
@@ -53,23 +53,23 @@
         <!-- If the value "default" is passed into the param then we will first
              load the standard css files associated with the theme -->
         {{ if or (in ($.Scratch.Get "cssFiles") "default") (eq ($.Scratch.Get "cssFiles") false) }}
-            <link rel="stylesheet" href="/css/google-font.css" />
-            <link rel="stylesheet" href="/css/font-awesome.min.css" />
-            <link rel="stylesheet" href="/css/main.css" />
-            <link rel="stylesheet" href="/css/add-on.css" />
-            <link rel="stylesheet" href="/css/monokai-sublime.css">
+            <link rel="stylesheet" href="{{ "/css/google-font.css" | relURL }}" />
+            <link rel="stylesheet" href="{{ "/css/font-awesome.min.css" | relURL }}" />
+            <link rel="stylesheet" href="{{ "/css/main.css" | relURL }}" />
+            <link rel="stylesheet" href="{{ "/css/add-on.css" | relURL }}" />
+            <link rel="stylesheet" href="{{ "/css/monokai-sublime.css" | relURL }}">
         {{ end }}
 
         {{ if ne ($.Scratch.Get "cssFiles") false }}
             {{ range $.Scratch.Get "cssFiles" }}
                 {{ if ne . "default" }}
-                    <link rel="stylesheet" href="{{ . }}" />
+                    <link rel="stylesheet" href="{{ . | relURL }}" />
                 {{ end }}
             {{ end }}
         {{ end }}
 
-        <!--[if lte IE 9]><link rel="stylesheet" href="/css/ie9.css" /><![endif]-->
-        <!--[if lte IE 8]><link rel="stylesheet" href="/css/ie8.css" /><![endif]-->
+        <!--[if lte IE 9]><link rel="stylesheet" href="{{ "/css/ie9.css" | relURL }}" /><![endif]-->
+        <!--[if lte IE 8]><link rel="stylesheet" href="{{ "/css/ie8.css" | relURL }}" /><![endif]-->
         {{ if not (in (printf "%#v" .Site.BaseURL) "localhost") }}
             {{ template "_internal/google_analytics.html" . }}
         {{ end }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,9 +1,9 @@
 <!-- Header -->
 <header id="header">
     {{ if and (.IsNode) (or (.IsHome) (eq .Title "Posts")) }}
-        <h1><a href="/">{{ .Site.Params.navbarTitle }}</i></a></h1>
+        <h1><a href="{{ "/" | relURL }}">{{ .Site.Params.navbarTitle }}</i></a></h1>
     {{ else }}
-        <h2><a href="/">{{ .Site.Params.navbarTitle }}</i></a></h2>
+        <h2><a href="{{ "/" | relURL }}">{{ .Site.Params.navbarTitle }}</i></a></h2>
     {{ end }}
 
     <nav class="links">

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -6,11 +6,11 @@
             {{ $pic := .Site.Params.intro.pic }}
             {{ with $pic.src }}
                 {{ if $pic.circle }}
-                    <img src="{{ . }}" class="intro-circle" width="{{ $pic.width }}" alt="{{ $pic.alt }}" />
+                    <img src="{{ . | relURL }}" class="intro-circle" width="{{ $pic.width }}" alt="{{ $pic.alt }}" />
                 {{ else if $pic.imperfect }}
-                    <a href="/" class="logo"><img src="{{ . }}" alt="{{ $pic.alt }}" /></a>
+                    <a href="{{ "/" | relURL }}" class="logo"><img src="{{ . | relURL }}" alt="{{ $pic.alt }}" /></a>
                 {{ else }}
-                    <img src="{{ . }}" width="{{ $pic.width }}" alt="{{ $pic.alt }}" />
+                    <img src="{{ . | relURL }}" width="{{ $pic.width }}" alt="{{ $pic.alt }}" />
                 {{ end }}
             {{ end }}
             {{ with .Site.Params.intro }}
@@ -102,7 +102,7 @@
                     <li>
                         <article>
                             <header>
-                                <a href="/categories/{{ $value.Name | urlize }}/">{{ $value.Name }}</a>
+                                <a href="{{ printf "/categories/%s" ( $value.Name | urlize ) | relURL }}">{{ $value.Name }}</a>
                                 <span style="float:right;">{{ $value.Count }}</span>
                             </header>
                         </article>
@@ -119,7 +119,7 @@
             <p>{{ . }}</p>
 
             <ul class="actions">
-                <li><a href="/about/" class="button">Learn More</a></li>
+                <li><a href="{{ "/about/" | relURL }}" class="button">Learn More</a></li>
             </ul>
         </section>
         {{ end }}

--- a/layouts/post/featured.html
+++ b/layouts/post/featured.html
@@ -7,7 +7,7 @@
         {{ $path := $.Scratch.Get "path" }}
 
         <a href="{{ .Permalink }}" class="image featured">
-            <img src="{{ $path }}/{{ .Params.featured }}" alt="{{ .Params.featuredalt }}" />
+            <img src="{{ printf "%s/%s" $path .Params.featured | relURL }}" alt="{{ .Params.featuredalt }}" />
         </a>
     {{ end }}
 {{ end }}

--- a/layouts/taxonomy/category.terms.html
+++ b/layouts/taxonomy/category.terms.html
@@ -19,7 +19,7 @@
                 <li>
                     <article>
                         <header>
-                            <a href="/{{ $data.Plural }}/{{ $value.Name | urlize }}">{{ $value.Name }}</a>
+                            <a href="{{ printf "/%s/%s" $data.Plural ($value.Name | urlize) | relURL }}">{{ $value.Name }}</a>
                             <span style="float:right;">{{ $value.Count }}</span>
                         </header>
                     </article>


### PR DESCRIPTION
I have updated all the links to js, css, img, and other files that are
local to use the relURL command in the template. This allows for base
URLs that are nested below the root (ie. https://mysite.com/blog instead of
just https://blog.mysite.com/ ). This commit fixes #22.
