### PR TITLE
Option to disable RSS icon in sidebar

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -27,6 +27,9 @@ googleAnalytics = ""
     loadFavicon          = false
     faviconVersion       = ""
 
+    # Disable showing the social sharing links on blog posts
+    # socialShareDisabled = true
+
     # Load custom CSS or JavaScript files. This replaces the deprecated params
     # minifiedFilesCSS and minifiedFilesJS. The variable is an array so that you
     # can load multiple files if necessary. You can also load the standard theme

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -33,9 +33,6 @@ googleAnalytics = ""
     loadFavicon          = false
     faviconVersion       = ""
 
-    # Disable showing the social sharing links on blog posts
-    # socialShareDisabled = true
-
     # Load custom CSS or JavaScript files. This replaces the deprecated params
     # minifiedFilesCSS and minifiedFilesJS. The variable is an array so that you
     # can load multiple files if necessary. You can also load the standard theme

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -12,9 +12,15 @@ googleAnalytics = ""
     description          = "HTML5 UP theme, Future Imperfect with some extra goodies, ported by Julio Pescador. Powered by Hugo"
     # This will appear on the top left of the navigation bar
     navbarTitle          = "Future Imperfect"
+
+    # RSS icon that appear on the sidebar, next to the social media buttons
+    rssAppearAtTop       = true
+    rssAppearAtBottom    = true
+
     # Social media buttons that appear on the sidebar
     socialAppearAtTop    = true
     socialAppearAtBottom = true
+
     # set this to the section name if section is not post
     viewMorePostLink     = "/blog/"
 

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -20,7 +20,7 @@
                 </header>
             {{ end }}
             <ul class="icons">
-                {{ if .RSSLink }}
+                {{ if and (.RSSLink) (.Site.Params.rssAppearAtTop) }}
                     <li><a href="{{ .RSSLink }}" type="application/rss+xml"
                         target="_blank" title="RSS" class="fa fa-rss"></a></li>
                 {{ end }}
@@ -127,7 +127,7 @@
     <!-- Footer -->
         <section id="footer">
             <ul class="icons">
-                {{ if .RSSLink }}
+                {{ if and (.RSSLink) (.Site.Params.rssAppearAtBottom) }}
                     <li><a href="{{ .RSSLink }}" type="application/rss+xml"
                         target="_blank" title="RSS" class="fa fa-rss"></a></li>
                 {{ end }}

--- a/layouts/post/content-single.html
+++ b/layouts/post/content-single.html
@@ -1,11 +1,14 @@
 <article class="post">
     {{ .Render "header" }}
 
+    {{ if not .Site.Params.socialShareDisabled }}
     <section id="social-share">
         <ul class="icons">
             {{ partial "share-links" . }}
         </ul>
     </section>
+    {{ end }}
+
     {{ .Render "featured" }}
     <div id="content">
         {{ .Content }}

--- a/layouts/post/content-single.html
+++ b/layouts/post/content-single.html
@@ -1,14 +1,11 @@
 <article class="post">
     {{ .Render "header" }}
 
-    {{ if not .Site.Params.socialShareDisabled }}
     <section id="social-share">
         <ul class="icons">
             {{ partial "share-links" . }}
         </ul>
     </section>
-    {{ end }}
-
     {{ .Render "featured" }}
     <div id="content">
         {{ .Content }}


### PR DESCRIPTION
Adds two new options:

- rssAppearAtTop
- rssAppearAtBottom

Just to be able to hide the buttons next to the social media buttons.