### PR TITLE
Allow using Description instead of Summary if available in list view

### DIFF
--- a/layouts/post/content-list.html
+++ b/layouts/post/content-list.html
@@ -1,7 +1,13 @@
 <article class="post">
     {{ .Render "header" }}
     {{ .Render "featured" }}
-    <p>{{ printf "%s" .Summary | markdownify }}</p>
+    <p>
+    {{if .Description }}
+        {{ printf "%s" .Description }}
+    {{ else }}
+        {{ printf "%s" .Summary | markdownify }}
+    {{ end }}
+    </p>
 
     <footer>
         <ul class="actions">


### PR DESCRIPTION
Sometimes one needs more control over the preview of the posts shown in list views. Allow using the Description front matter in such cases.

Please let me know if pull requests like these are helpful or if I should stop.
I am making a few more changes on my end to use this in my personal blog.