### PR TITLE
Fix: relURL missing / Issue #22 

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,4 +1,4 @@
-baseurl = "http://hugo.spf13.com/"
+baseurl = "/"
 languageCode = "en-us"
 title = "Hugo Future Imperfect"
 theme = "hugo-future-imperfect"

--- a/layouts/partials/favicon.html
+++ b/layouts/partials/favicon.html
@@ -1,18 +1,18 @@
 {{ if .Site.Params.loadFavicon }}
-    {{ with .Site.Params.faviconVersion }}
-        {{ $.Scratch.Set "favVer" "-" }}
-        {{ $.Scratch.Add "favVer" . }}
-    {{ else }}
-        {{ $.Scratch.Set "favVer" "" }}
-    {{ end }}
+  {{ with .Site.Params.faviconVersion }}
+    {{ $.Scratch.Set "favVer" "-" }}
+    {{ $.Scratch.Add "favVer" . }}
+  {{ else }}
+    {{ $.Scratch.Set "favVer" "" }}
+  {{ end }}
 
-    {{ $favVer := $.Scratch.Get "favVer" }}
+  {{ $favVer := $.Scratch.Get "favVer" }}
 
-    <link rel="apple-touch-icon-precomposed"
-        href='/favicon/apple-touch-icon-precomposed{{ $favVer }}.png'>
-    <link rel="icon" href='/favicon/favicon{{ $favVer }}.png'>
-    <!--[if IE]><link rel="shortcut icon" href='/favicon{{ $favVer }}.ico'><![endif]-->
-    <meta name="msapplication-TileColor" content="#da532c">
-    <meta name="msapplication-TileImage"
-        content='/favicon/mstile{{ $favVer }}.png'>
+  <link rel="apple-touch-icon-precomposed"
+    href='{{"/favicon/apple-touch-icon-precomposed" | relURL }}{{ $favVer }}.png'>
+  <link rel="icon" href='{{"/favicon/favicon" | relURL }}/favicon/favicon{{ $favVer }}.png'>
+  <!--[if IE]><link rel="shortcut icon" href='/favicon{{ $favVer }}.ico'><![endif]-->
+  <meta name="msapplication-TileColor" content="#da532c">
+  <meta name="msapplication-TileImage"
+      content='/favicon/mstile{{ $favVer }}.png'>
 {{ end }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,11 +1,11 @@
 <!-- Header -->
 <header id="header">
     {{ if .IsHome }}
-      <h1><a href="/">{{ .Site.Params.navbarTitle }}</a></h1>
+      <h1><a href="{{ .Site.BaseURL }}">{{ .Site.Params.navbarTitle }}</a></h1>
     {{ else if ne .Section "" }}
-      <h1><a href="/">{{ .Section }}</a></h1>
+      <h1><a href="{{ .Site.BaseURL }}">{{ .Section }}</a></h1>
     {{ else }}
-      <h1><a href="/">{{ .Title }}</a></h1>
+      <h1><a href="{{ .Site.BaseURL }}">{{ .Title }}</a></h1>
     {{ end }}
 
     <nav class="links">

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -6,11 +6,11 @@
     {{ $pic := .Site.Params.intro.pic }}
     {{ with $pic.src }}
       {{ if $pic.circle }}
-        <img src="{{ . }}" class="intro-circle" width="{{ $pic.width }}" alt="{{ $pic.alt }}">
+        <a href='{{"/" | relURL}}'><img src="{{ . | relURL }}" class="intro-circle" width="{{ $pic.width }}" alt="{{ $pic.alt }}" /></a>
       {{ else if $pic.imperfect }}
-        <a href="/" class="logo"><img src="{{ . }}" alt="{{ $pic.alt }}" /></a>
+        <a href='{{"/" | relURL}}' class="logo"><img src="{{ . | relURL }}" alt="{{ $pic.alt }}" /></a>
       {{ else }}
-        <img src="{{ . }}" width="{{ $pic.width }}" alt="{{ $pic.alt }}">
+        <a href='{{"/" | relURL}}'><img src="{{ . | relURL }}" width="{{ $pic.width }}" alt="{{ $pic.alt }}" /></a>
       {{ end }}
     {{ end }}
     {{ with .Site.Params.intro }}

--- a/layouts/post/featured.html
+++ b/layouts/post/featured.html
@@ -9,7 +9,7 @@
         {{ $img := $.Scratch.Get "img" }}
 
         <a href="{{ .Permalink }}" class="image featured">
-            <img src="{{ $path }}/{{ .Params.featured }}" alt="{{ $alt }}">
+            <img src="{{ $path | relURL }}/{{ .Params.featured }}" alt="{{ $alt }}">
         </a>
     {{ end }}
 {{ end }}

--- a/layouts/taxonomy/category.terms.html
+++ b/layouts/taxonomy/category.terms.html
@@ -20,7 +20,7 @@
                     <article>
                         <header>
                             {{ if ne $value.Name "" }}
-                                <a href="/{{ $data.Plural }}/{{ $value.Name | urlize }}">{{ $value.Name }}</a>
+                                <a href="{{"/" | relURL}}{{ $data.Plural }}/{{ $value.Name | urlize }}">{{ $value.Name }}</a>
                                 <span style="float:right;">{{ $value.Count }}</span>
                             {{ else }}
                                 Uncategorized


### PR DESCRIPTION
Adding relURL, so that a website laying in a subfolder is also shown properly

Issue #22 was not completly fixed


## Description
  * I added relURL or .Site.BaseURL at places necessary.
  * Furthermore, I adopted the line wrapping in favicon.html to the new style proposal

## Motivation and Context
If the website is not hosted at a primary domain like https://example.com/ , but instead on a subdomain like https://example.com/subdomain, some links were not resolved properly.

Further fix for issue  #22 

## How Has This Been Tested?

Tested on my own setup:
 * Tested with hugo server locally 
 * Tested via a deployment to Gitlab pages with subdomain.



**Hugo Version:** 0.30.2

**Browser(s):** Firefox, Chromium, Chrome

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the [code style] of this project.
- [ ] My change requires a change to the [documentation].
- [ ] I have updated the documentation, including `theme.toml`, accordingly.
- [x] I have read the [Contributing Document].

[Code Style]: https://github.com/jpescador/hugo-future-imperfect/blob/master/.github/CONTRIBUTING.md#Style-Guide
[Contributing Document]: https://github.com/jpescador/hugo-future-imperfect/blob/master/.github/CONTRIBUTING.md
[Documentation]: https://github.com/jpescador/hugo-future-imperfect/wiki
