### PR TITLE
Fix: rssAppearAtBottom and rssAppearAtTop usage

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -21,7 +21,7 @@
     {{ end }}
     {{ if .Site.Params.socialAppearAtTop }}
       <ul class="icons">
-        {{ if .RSSLink }}
+        {{ if .Site.Params.rssAppearAtTop }}
           <li>
             <a href="{{ .RSSLink }}" type="application/rss+xml" target="_blank" title="RSS" class="fa fa-rss"></a>
           </li>
@@ -121,7 +121,7 @@
   <section id="footer">
     {{ if .Site.Params.socialAppearAtBottom }}
       <ul class="icons">
-        {{ if .RSSLink }}
+        {{ if .Site.Params.rssAppearAtBottom }}
           <li>
             <a href="{{ .RSSLink }}" type="application/rss+xml" target="_blank" title="RSS" class="fa fa-rss"></a>
           </li>


### PR DESCRIPTION
rssAppearAtBottom and rssAppearAtTop defined in config.toml file but not considered in sidebar

<!--- Prerequisites -->
<!--- I am running the latest version of [Hugo](https://github.com/gohugoio/hugo/releases) -->
<!--- I am using the latest version of [Hugo-Future-Imperfect](https://github.com/jpescador/hugo-future-imperfect/releases) -->
<!--- I checked the [issues](https://github.com/jpescador/hugo-future-imperfect/issues?utf8=%E2%9C%93&q=is%3Aissue) to make sure that this feature has not been rejected before -->
<!--- I checked the [pull requests](https://github.com/jpescador/hugo-future-imperfect/pulls?utf8=%E2%9C%93&q=is%3Apr) to make sure that this feature is not already being developed -->

<!--- Provide a general summary of your changes in the Title above -->
 * Made sure that the config options rssAppearAtBottom and rssAppearAtTop are considered in sidebar.html

## Description
Replaced deprecated check for .RSS option with check for either
  * .Site.Params.rssAppearAtTop
  * .Site.Params.rssAppearAtBottom

## Motivation and Context
Fixing a bug.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on my own setup:

  * Tested with hugo server locally
  * Tested via a deployment to Gitlab pages with subdomain.



**Hugo Version:** 0.30.2

**Browser(s):** Firefox, Chromium, Chrome

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the [code style] of this project.
- [ ] My change requires a change to the [documentation].
- [ ] I have updated the documentation, including `theme.toml`, accordingly.
- [x] I have read the [Contributing Document].

[Code Style]: https://github.com/jpescador/hugo-future-imperfect/blob/master/.github/CONTRIBUTING.md#Style-Guide
[Contributing Document]: https://github.com/jpescador/hugo-future-imperfect/blob/master/.github/CONTRIBUTING.md
[Documentation]: https://github.com/jpescador/hugo-future-imperfect/wiki
