### PR TITLE
Feature: Table of contents in blog articles

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -45,6 +45,12 @@ pluralizeListTitles = false
   customCSS            = ["default"]
   customJS             = ["default"]
 
+  # Decide if blog articles have a toc
+  # Note: You can deactivate a toc for a single article via setting parameter tocActivated = "false" in article config
+  tocIfNecessary = true
+  # Min. number of words in article after which toc gets generated
+  tocWordCount = 500
+
 # Disqus will take priority over Staticman (github.com/eduardoboucas/staticman)
 # due to its ease of use. Feel free to check out both and decide what you would
 # prefer to use. See Staticman.yml for additional settings.

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,0 +1,10 @@
+<!--
+Taken from Hugo manual: Show toc after site has word count larger than some value
+toc generation can be stopped by adding a parameter tocFalse to the content
+-->
+
+{{ if and (.Site.Params.tocIfNecessary) (gt .WordCount .Site.Params.tocWordCount) (ne .Params.tocActivated "false") }}
+<aside>
+  {{.TableOfContents}}
+</aside>
+{{ end }}

--- a/layouts/post/content-single.html
+++ b/layouts/post/content-single.html
@@ -11,6 +11,7 @@
 
   {{ .Render "featured" }}
   <div id="content">
+    {{ partial "toc" . }}
     {{ .Content }}
   </div>
 


### PR DESCRIPTION
One can activate a table of contents for blog articles if the word count gets larger than a specified parameter.

Parameters in config.toml:
tocIfNecessary = true
  # Min. number of words in article after which toc gets generated
  tocWordCount = 500
Additionally, one can deactivate the toc for single blog articles by adding tocActivated = false to the article config

<!--- Prerequisites -->
<!--- I am running the latest version of [Hugo](https://github.com/gohugoio/hugo/releases) -->
<!--- I am using the latest version of [Hugo-Future-Imperfect](https://github.com/jpescador/hugo-future-imperfect/releases) -->
<!--- I checked the [issues](https://github.com/jpescador/hugo-future-imperfect/issues?utf8=%E2%9C%93&q=is%3Aissue) to make sure that this feature has not been rejected before -->
<!--- I checked the [pull requests](https://github.com/jpescador/hugo-future-imperfect/pulls?utf8=%E2%9C%93&q=is%3Apr) to make sure that this feature is not already being developed -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here with "Closes #XXX" -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Hugo Version:**

**Browser(s):**

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the [code style] of this project.
- [ ] My change requires a change to the [documentation].
- [ ] I have updated the documentation, including `theme.toml`, accordingly.
- [ ] I have read the [Contributing Document].

[Code Style]: https://github.com/jpescador/hugo-future-imperfect/blob/master/.github/CONTRIBUTING.md#Style-Guide
[Contributing Document]: https://github.com/jpescador/hugo-future-imperfect/blob/master/.github/CONTRIBUTING.md
[Documentation]: https://github.com/jpescador/hugo-future-imperfect/wiki
