### PR TITLE
fix dynamicTitles param being ignored

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,6 +1,6 @@
 <!-- Header -->
 <header id="header">
-    {{ if .IsHome }}
+    {{ if or .IsHome (not .Site.Params.DynamicTitles) }}
       <h1><a href="{{ "/" | relURL }}">{{ .Site.Params.navbarTitle }}</a></h1>
     {{ else if ne .Section "" }}
       <h1><a href="{{ "/" | relURL }}">{{ .Section }}</a></h1>


### PR DESCRIPTION
This makes the `dynamicTitles` param work: When set to true (default), the navbar title is set to the section, if set to false, it's always `navbarTitle`.