### PR TITLE
Staticman Updates to make comments work more easily with less configuration

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -56,6 +56,10 @@ pluralizeListTitles = false
   repo      = ""
   branch    = ""
 
+  [params.staticman.recaptcha]
+    sitekey = "SITE_KEY"
+    secret  = "ENCRYPTED_SECRET"
+
   # These are optional params related to the sidebar. They are recommended, but not
   # required for proper functionality. HTML is supported within the params.
 [params.intro]

--- a/layouts/post/staticman.html
+++ b/layouts/post/staticman.html
@@ -1,16 +1,16 @@
 <h2>Say something</h2>
 {{ with .Site.Params.staticman }}
-  <form class="post-new-comment" method="POST" action="https://dev.staticman.net/v2/entry/{{ .username }}/{{ .repo }}/{{ .branch }}/comments">
+  <form class="post-new-comment" method="POST" action="https://api.staticman.net/v2/entry/{{ .username }}/{{ .repo }}/{{ .branch }}/comments">
 {{ end }}
-    <input type="hidden" name="options[redirect]" value="{{ .RelPermalink }}">
+    <input type="hidden" name="options[redirect]" value="{{ .Site.BaseURL }}{{ .RelPermalink }}">
     <input type="hidden" name="options[entryId]" value="{{ .UniqueID }}">
     <input required name="fields[name]" type="text" placeholder="Your name (Required)">
     <input name="fields[website]" type="text" placeholder="Your website">
     <input required name="fields[email]" type="email" placeholder="Your email address (Required for Gravatar)">
     <textarea required name="fields[body]" placeholder='Your message. Feel free to use Markdown (Google "Markdown Cheat Sheet").' rows="10"></textarea>
-    <input type="hidden" name="options[reCaptcha][siteKey]" value="6LeoGzAUAAAAAEQyc2O1okFJPFsYFgryXvpLkFJ1">
-    <input type="hidden" name="options[reCaptcha][secret]" value="A2bqZay+pf0qOpY/GARlzqV7Bq9U4JzQhipNYlh44Zd7+aGYFc+5hArV5zVXl1tVHtPPL/o1BCDhy6EKiBP8eupxN4o1ISpbk5bpREJTPVgA+zSDiPmfJ4U6JNjmp752gjLcv4JOvJYzNeRnu23ZjjbT497f5EIdWRGBJGa/OHA=">
-    <div class="g-recaptcha" data-sitekey="6LeoGzAUAAAAAEQyc2O1okFJPFsYFgryXvpLkFJ1"></div>
+    <input type="hidden" name="options[reCaptcha][siteKey]" value="{{ .Site.Params.staticman.recaptcha.sitekey }}">
+    <input type="hidden" name="options[reCaptcha][secret]" value="{{ .Site.Params.staticman.recaptcha.secret }}">
+    <div class="g-recaptcha" data-sitekey="{{ .Site.Params.staticman.recaptcha.sitekey }}"></div>
     <input type="submit" value="Submit">
   </form>
 <script src='https://www.google.com/recaptcha/api.js'></script>


### PR DESCRIPTION
config and staticman.html updates to make comments work out of the box more easily. May want to add conditional for reCAPTCHA in the future incase they don't use it

<!--- Prerequisites -->
<!--- I am running the latest version of [Hugo](https://github.com/gohugoio/hugo/releases) YES -->
<!--- I am using the latest version of [Hugo-Future-Imperfect](https://github.com/jpescador/hugo-future-imperfect/releases) YES -->
<!--- I checked the [issues](https://github.com/jpescador/hugo-future-imperfect/issues?utf8=%E2%9C%93&q=is%3Aissue) to make sure that this feature has not been rejected before YES -->
<!--- I checked the [pull requests](https://github.com/jpescador/hugo-future-imperfect/pulls?utf8=%E2%9C%93&q=is%3Apr) to make sure that this feature is not already being developed YES -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Updated `config.toml` to include 2 new parameters `sitekey` and `secret` under `[params.staticman.recaptcha]` so that these variables can be referenced more easily in the `staticman.html` template.
- Updated the following fields to use the additions above with correct information according to Staticman documentation:
  - `form` used incorrect `action` url before update
  - `input _options[redirect]_`
  - `input _options[reCaptcha][siteKey]_`
  - `input _options[reCaptcha][secret]_`
  - `div _class="g-recaptcha"_`

### Possible ToDo:
- [ ] Add conditional check to see if reCAPTCHA is being used. Don't need check for staticman as it already exists.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Wanted Staticman comments but kept getting errors when using in production environment but none when tested locally. Reconfigured everything to work correctly after following the Staticman documentation to setup and made it easier for future users to setup.
<!--- If it fixes an open issue, please link to the issue here with "Closes #XXX" -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested locally (which always worked even before change) as well as in production at [BernCarney.com](https://berncarney.com) with dummy comments. In production, prior to changes, reCAPTCHA would have an error when being used with wrong site key and secret, and when that was corrected there would be a redirect error. All working correctly now with my tests with dummy comments.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Hugo Version:**
0.31.1

**Browser(s):**
Firefox, Chrome

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the [code style] of this project.
- [x] My change requires a change to the [documentation].
- [ ] I have updated the documentation, including `theme.toml`, accordingly.
- [x] I have read the [Contributing Document].

[Code Style]: https://github.com/jpescador/hugo-future-imperfect/blob/master/.github/CONTRIBUTING.md#Style-Guide
[Contributing Document]: https://github.com/jpescador/hugo-future-imperfect/blob/master/.github/CONTRIBUTING.md
[Documentation]: https://github.com/jpescador/hugo-future-imperfect/wiki
