### PR TITLE
Recent posts should be a class not ID

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -67,7 +67,7 @@
         </section>
 
     <!-- Posts List -->
-        <section id="recent-posts">
+        <section class="recent-posts">
             <div class="mini-posts">
                 <header>
                     <h3>Recent Posts</h3>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -32,7 +32,7 @@
   </section>
 
   <!-- Posts List -->
-  <section id="recent-posts">
+  <section class="recent-posts">
     <div class="mini-posts">
       <header>
         <h3>Recent Posts</h3>


### PR DESCRIPTION
## Prerequisites:
* Hugo Static Site Generator v0.32.1 linux/amd64 BuildDate: 2018-01-02T23:03:31+01:00
* Using Hugo-Imperfect-Future ref: 3b30bf0b62ea4341d0f72504d9ecb6a6eeda22fb

## Expected Behaviour
Output HTML is valid. Elements with an ID should only appear once. For elements that appear more than once should use CLASS.

## Current Behavior
`recent-posts` section appears in the HTML code twice, with an ID rather than class. This causes HTML validation to fail. The section appears twice on all rendered pages.

```
<section id="recent-posts">

  <div class="mini-posts">
  <header>
  <h3>Recent Posts</h3>
  </header>
   
   
    
    
    
    
    
  <article class="mini-post">
  <header>
  <h3><a href="/blog/welcome/">Home</a></h3>
    
  <time class="published" datetime=
  '2017-11-12'>
  November 12, 2017</time>
  </header>
   
   
  </article>
   
    
   
  </div>
  </section>
```


## Possible Solution
```
<section class="recent-posts">
```
With CSS updated to match.

## Steps to Reproduce or Template with Error (for bugs)
* Goto: https://themes.gohugo.io/theme/future-imperfect/
* View source
* Search "recent-posts"

## Context
Attempting to use Hugo with CI. For the testing stage trying to use HTML proofer. So far this theme as a few failures, this being one of them. I really like the theme, so would like to try and get them resolved. I am happy to submit a PR if it helps?

## Your Environment
https://gitlab.com/rlees85-hugo/bitservices/

## Fixes
https://github.com/jpescador/hugo-future-imperfect/issues/102
