### PR TITLE
Share links - use &amp;

### DIFF
--- a/layouts/partials/share-links.html
+++ b/layouts/partials/share-links.html
@@ -2,7 +2,7 @@
 
 <!-- Twitter -->
 <li>
-  <a href="//twitter.com/share?url={{ .Permalink }}&text={{ .Title }}&via={{ .Site.Social.twitter }}" target="_blank" class="share-btn twitter">
+  <a href="//twitter.com/share?url={{ .Permalink }}&amp;text={{ .Title }}&amp;via={{ .Site.Social.twitter }}" target="_blank" class="share-btn twitter">
     <i class="fa fa-twitter"></i>
     <p>Twitter</p>
     </a>
@@ -26,7 +26,7 @@
 
 <!-- Reddit -->
 <li>
-  <a href="//reddit.com/submit?url={{ .Permalink }}&title={{ .Title }}" target="_blank" class="share-btn reddit">
+  <a href="//reddit.com/submit?url={{ .Permalink }}&amp;title={{ .Title }}" target="_blank" class="share-btn reddit">
     <i class="fa fa-reddit-alien"></i>
     <p>Reddit</p>
   </a>
@@ -34,7 +34,7 @@
 
 <!-- LinkedIn -->
 <li>
-  <a href="//www.linkedin.com/shareArticle?url={{ .Permalink }}&title={{ .Title }}" target="_blank" class="share-btn linkedin">
+  <a href="//www.linkedin.com/shareArticle?url={{ .Permalink }}&amp;title={{ .Title }}" target="_blank" class="share-btn linkedin">
       <i class="fa fa-linkedin"></i>
       <p>LinkedIn</p>
     </a>
@@ -42,7 +42,7 @@
 
 <!-- StumbleUpon -->
 <li>
-  <a href="//www.stumbleupon.com/submit?url={{ .Permalink }}&title={{ .Title }}" target="_blank" class="share-btn stumbleupon">
+  <a href="//www.stumbleupon.com/submit?url={{ .Permalink }}&amp;title={{ .Title }}" target="_blank" class="share-btn stumbleupon">
     <i class="fa fa-stumbleupon"></i>
     <p>StumbleUpon</p>
   </a>
@@ -50,7 +50,7 @@
 
 <!-- Pintrest -->
 <li>
-  <a href="//www.pinterest.com/pin/create/button/?url={{ .Permalink }}&description={{ .Title }}" target="_blank" class="share-btn pinterest">
+  <a href="//www.pinterest.com/pin/create/button/?url={{ .Permalink }}&amp;description={{ .Title }}" target="_blank" class="share-btn pinterest">
     <i class="fa fa-pinterest-p"></i>
     <p>Pinterest</p>
   </a>
@@ -58,7 +58,7 @@
 
 <!-- Email -->
 <li>
-  <a href="mailto:?subject=Check out this post by {{ .Params.author }}&body={{ .Permalink }}" target="_blank" class="share-btn email">
+  <a href="mailto:?subject=Check out this post by {{ .Params.author }}&amp;body={{ .Permalink }}" target="_blank" class="share-btn email">
     <i class="fa fa-envelope"></i>
     <p>Email</p>
   </a>

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -97,7 +97,7 @@
 {{ end }}
 
 {{ with .Site.Social.qq }}
-  <li><a href="//wpa.qq.com/msgrd?v=3&uin={{.}}&site=qq&menu=yes" target="_blank" title="QQ" class="fa fa-qq"></a></li>
+  <li><a href="//wpa.qq.com/msgrd?v=3&amp;uin={{.}}&amp;site=qq&amp;menu=yes" target="_blank" title="QQ" class="fa fa-qq"></a></li>
 {{ end }}
 
 {{ with .Site.Social.instagram }}


### PR DESCRIPTION
## Description
The `share-links.html` **partial** contains hyperlinks that have the `&` character specified. In HTML, the `&` character should always be escaped, as `&amp;`

## Motivation and Context
The motivation is for the theme to generate correct and valid HTML.

## How Has This Been Tested?
Ran the commit on my own fork. Tested the links in both Chromium browser and Firefox, both exhibited the correct behaviour. The HTML proofer tests that were failing due to the non-valid HTML now pass.

**Hugo Version:** Hugo Static Site Generator v0.32.4 linux/amd64 BuildDate: 2018-01-11T22:17:02+01:00

**Browser(s):** Chromium, Firefox

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the [code style] of this project.
- [ ] My change requires a change to the [documentation].
- [ ] I have updated the documentation, including `theme.toml`, accordingly.
- [ ] I have read the [Contributing Document].

**Note**: If any of the above will prevent the PR being merged, I am happy to read the [Contributing Document] and the [code style] of this project.

[Code Style]: https://github.com/jpescador/hugo-future-imperfect/blob/master/.github/CONTRIBUTING.md#Style-Guide
[Contributing Document]: https://github.com/jpescador/hugo-future-imperfect/blob/master/.github/CONTRIBUTING.md
[Documentation]: https://github.com/jpescador/hugo-future-imperfect/wiki
