### PR TITLE
Add OpenGraph meta tags

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -34,6 +34,10 @@
 
         {{ template "_internal/twitter_cards.html" . }}
         {{ template "_internal/opengraph.html" . }}
+        <meta property="og:image" content="{{ .Site.BaseURL }}/images/logo.png">
+        <meta property="og:image:type" content="image/png">
+        <meta property="og:image:width" content="512">
+        <meta property="og:image:height" content="512">
         {{ template "_internal/schema.html" . }}
         {{ template "_internal/google_news.html" . }}
 


### PR DESCRIPTION
## Description
This PR adds generig OpenGraph meta tags, using normal configuration parameters.

## Motivation and Context
I reworked the theme of our blog in a proper fork: https://github.com/facile-it/hugo-future-imperfect
I'm reporting upstream this change.

## How Has This Been Tested?
This modification is currently in production on our blog: https://engineering.facile.it/

**Hugo Version:** 0.31.1

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [code style] of this project.
- [ ] My change requires a change to the [documentation].
- [ ] I have updated the documentation, including `theme.toml`, accordingly.
- [x] I have read the [Contributing Document].