### PR TITLE
Remove duplicate inclusion of Highlight.js

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -24,7 +24,6 @@
      load the standard js files associated with the theme -->
     {{ if or (in ($.Scratch.Get "jsFiles") "default") (eq ($.Scratch.Get "jsFiles") false) }}
       <script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/skel/3.0.1/skel.min.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.1.25/jquery.fancybox.min.js"></script>
       <script src="{{ "js/util.js" | relURL }}"></script>


### PR DESCRIPTION
## Description
This PR removes a duplication in the JS inclusions.

## Motivation and Context
I reworked the theme of our blog in a proper fork: https://github.com/facile-it/hugo-future-imperfect
I'm reporting upstream this change.

## How Has This Been Tested?
This modification is currently in production on our blog: https://engineering.facile.it/

**Hugo Version:** 0.31.1

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [code style] of this project.
- [ ] My change requires a change to the [documentation].
- [ ] I have updated the documentation, including `theme.toml`, accordingly.
- [x] I have read the [Contributing Document].