### PR TITLE
Fixed the test condition

### DIFF
--- a/layouts/post/featured.html
+++ b/layouts/post/featured.html
@@ -1,7 +1,7 @@
 {{ if and (isset .Params "featuredpath") (ne .Params.featuredpath "") }}
     {{ $.Scratch.Set "path" .Params.featuredpath }}
 
-    {{ if and (isset .Params "featured") (ne .Params.featuredpath "") }}
+    {{ if and (isset .Params "featured") (ne .Params.featured "") }}
         {{ $.Scratch.Set "structType" "page" }}
         {{ partial "img-path" . }}
         {{ $path := $.Scratch.Get "path" }}


### PR DESCRIPTION
Fixed the unexpected behavior of the featured image. When I compile the old version, the image does not show up in few posts. Now, it works perfectly.

<!--- Prerequisites -->
<!--- I am running the latest version of [Hugo](https://github.com/gohugoio/hugo/releases) -->
<!--- I am using the latest version of [Hugo-Future-Imperfect](https://github.com/jpescador/hugo-future-imperfect/releases) -->
<!--- I checked the [issues](https://github.com/jpescador/hugo-future-imperfect/issues?utf8=%E2%9C%93&q=is%3Aissue) to make sure that this feature has not been rejected before -->
<!--- I checked the [pull requests](https://github.com/jpescador/hugo-future-imperfect/pulls?utf8=%E2%9C%93&q=is%3Apr) to make sure that this feature is not already being developed -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here with "Closes #XXX" -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Hugo Version:**

**Browser(s):**

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the [code style] of this project.
- [ ] My change requires a change to the [documentation].
- [ ] I have updated the documentation, including `theme.toml`, accordingly.
- [x] I have read the [Contributing Document].

[Code Style]: https://github.com/jpescador/hugo-future-imperfect/blob/master/.github/CONTRIBUTING.md#Style-Guide
[Contributing Document]: https://github.com/jpescador/hugo-future-imperfect/blob/master/.github/CONTRIBUTING.md
[Documentation]: https://github.com/jpescador/hugo-future-imperfect/wiki
