### PR TITLE
Layout/Sidebar: add support of Gravatar to fetch main picture

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -96,6 +96,9 @@ canonifyURLs = true
   # This appears at the top of the sidebar above params.intro.header.
   # A width of less than 100px is recommended from a design perspective.
   [params.intro.pic]
+    # Gravatar email to use to fetch the picture. This will override the `src`
+    # field if set.
+    gravatar  = ""
     src       = "/img/main/logo.jpg"
     # Sets Image to be a cirlce
     circle    = false

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -5,12 +5,18 @@
   <section id="intro">
     {{ $pic := .Site.Params.intro.pic }}
     {{ with $pic.src }}
+      {{ $.Scratch.Set "picURL" (. | relURL )}}
+    {{ end }}
+    {{ with $pic.gravatar }}
+      {{ $.Scratch.Set "picURL" (printf "https://www.gravatar.com/avatar/%s?s=100&d=identicon" (. | md5) )}}
+    {{ end }}
+    {{ with $.Scratch.Get "picURL" }}
       {{ if $pic.circle }}
-        <a href='{{"/" | relURL}}'><img src="{{ . | relURL }}" class="intro-circle" width="{{ $pic.width }}" alt="{{ $pic.alt }}" /></a>
+        <a href='{{"/" | relURL}}'><img src="{{ $.Scratch.Get "picURL" }}" class="intro-circle" width="{{ $pic.width }}" alt="{{ $pic.alt }}" /></a>
       {{ else if $pic.imperfect }}
-        <a href='{{"/" | relURL}}' class="logo"><img src="{{ . | relURL }}" alt="{{ $pic.alt }}" /></a>
+        <a href='{{"/" | relURL}}' class="logo"><img src="{{ $.Scratch.Get "picURL" }}" alt="{{ $pic.alt }}" /></a>
       {{ else }}
-        <a href='{{"/" | relURL}}'><img src="{{ . | relURL }}" width="{{ $pic.width }}" alt="{{ $pic.alt }}" /></a>
+        <a href='{{"/" | relURL}}'><img src="{{ $.Scratch.Get "picURL" }}" width="{{ $pic.width }}" alt="{{ $pic.alt }}" /></a>
       {{ end }}
     {{ end }}
     {{ with .Site.Params.intro }}


### PR DESCRIPTION
<!--- Prerequisites -->
<!--- I am running the latest version of [Hugo](https://github.com/gohugoio/hugo/releases) -->
<!--- I am using the latest version of [Hugo-Future-Imperfect](https://github.com/jpescador/hugo-future-imperfect/releases) -->
<!--- I checked the [issues](https://github.com/jpescador/hugo-future-imperfect/issues?utf8=%E2%9C%93&q=is%3Aissue) to make sure that this feature has not been rejected before -->
<!--- I checked the [pull requests](https://github.com/jpescador/hugo-future-imperfect/pulls?utf8=%E2%9C%93&q=is%3Apr) to make sure that this feature is not already being developed -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
It is currently only possible to directly reference an image for the main avatar/picture in the sidebar. This Pull Requests adds support for getting this image from [**Gravatar**](https://www.gravatar.com/) by only specifying the email address to look for in the hugo configuration (`config.{toml.yaml,json}`).

If the `gravatar` field of the `[params.intro.pic]` section is set, it will take precedence over the existing `src` field. This hence doesn't change anything for current users just updating the theme. The concerned `gravatar` field has been added to the example site configuration and defaults to an empty string, effectively disabling it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here with "Closes #XXX" -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Hugo Version:** Hugo Static Site Generator v0.37.1 linux/amd64 BuildDate: 2018-03-08T21:23:30+0100

**Browser(s):** Mozilla Firefox 59.0.1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the [code style] of this project.
- [ ] My change requires a change to the [documentation].
- [X] I have updated the documentation, including `theme.toml`, accordingly.
- [X] I have read the [Contributing Document].

[Code Style]: https://github.com/jpescador/hugo-future-imperfect/blob/master/.github/CONTRIBUTING.md#Style-Guide
[Contributing Document]: https://github.com/jpescador/hugo-future-imperfect/blob/master/.github/CONTRIBUTING.md
[Documentation]: https://github.com/jpescador/hugo-future-imperfect/wiki
