### PR TITLE
Make fancybox work with named parameters (bug fix)

### DIFF
--- a/layouts/shortcodes/fancybox.html
+++ b/layouts/shortcodes/fancybox.html
@@ -42,18 +42,19 @@
     {{ else }}
       {{ $.Scratch.Set "gallery" ""}}
     {{ end }}
-
-    {{ $.Scratch.Set "structType" "shortcode" }}
-    {{ partial "img-path" . }}
-
-    {{ $path := $.Scratch.Get "path" }}
-    {{ $file := $.Scratch.Get "file" }}
-    {{ $caption  := $.Scratch.Get "caption" }}
-    {{ $gallery := $.Scratch.Get "gallery" }}
-
-    <div class="fancybox">
-      <a data-fancybox="{{ $gallery }}" href="{{ $path }}/{{ $file }}" data-caption="{{ $caption }}"><img src="{{ $path }}/{{ $file }}"></a>
-      <!--<div class="caption">{{ $caption }}</div>-->
-    </div>
   {{ end }}
+
+  {{ $.Scratch.Set "structType" "shortcode" }}
+  {{ partial "img-path" . }}
+
+  {{ $path := $.Scratch.Get "path" }}
+  {{ $file := $.Scratch.Get "file" }}
+  {{ $caption  := $.Scratch.Get "caption" }}
+  {{ $gallery := $.Scratch.Get "gallery" }}
+
+  <div class="fancybox">
+    <a data-fancybox="{{ $gallery }}" href="{{ $path }}/{{ $file }}" data-caption="{{ $caption }}"><img src="{{ $path }}/{{ $file }}"></a>
+    <!--<div class="caption">{{ $caption }}</div>-->
+  </div>
+
 {{ end }}


### PR DESCRIPTION
<!--- Prerequisites -->
<!--- I am running the latest version of [Hugo](https://github.com/gohugoio/hugo/releases) -->
<!--- I am using the latest version of [Hugo-Future-Imperfect](https://github.com/jpescador/hugo-future-imperfect/releases) -->
<!--- I checked the [issues](https://github.com/jpescador/hugo-future-imperfect/issues?utf8=%E2%9C%93&q=is%3Aissue) to make sure that this feature has not been rejected before -->
<!--- I checked the [pull requests](https://github.com/jpescador/hugo-future-imperfect/pulls?utf8=%E2%9C%93&q=is%3Apr) to make sure that this feature is not already being developed -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
The `fancybox` shortcode currently only works with positional parameters. This is because the variable declarations and html were only inside the `else` branch for `{{ if .IsNamedParams }}`. 

This pull request moves up the `{{ end }}` tag so that our html is rendered whether or not we are using named parameters.

## How Has This Been Tested?
 - Added a `fancybox` shortcode using named parameters.
 - The image displayed correctly
 - Added a `fancybox` shortcode using positional parameters
 - The image displayed correctly

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Hugo Version: 0.37**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the [code style] of this project.
- [ ] My change requires a change to the [documentation].
- [ ] I have updated the documentation, including `theme.toml`, accordingly.
- [x] I have read the [Contributing Document].

[Code Style]: https://github.com/jpescador/hugo-future-imperfect/blob/master/.github/CONTRIBUTING.md#Style-Guide
[Contributing Document]: https://github.com/jpescador/hugo-future-imperfect/blob/master/.github/CONTRIBUTING.md
[Documentation]: https://github.com/jpescador/hugo-future-imperfect/wiki
