### PR TITLE
Fix unneeded highlight CSS, fix disable_highlight, clean up highlight template

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -62,7 +62,7 @@ canonifyURLs = true
 
   # options for highlight.js (version, additional languages, and theme)
   disable_highlight = false # set to true to disable Highlight
-  highlightjsVersion = "9.11.0"
+  highlightjsVersion = "9.12.0"
   highlightjsCDN = "//cdn.bootcss.com"
   highlightjsLang = ["r", "yaml", "css"]
   highlightjsTheme = "github"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -63,7 +63,7 @@ canonifyURLs = true
   # options for highlight.js (version, additional languages, and theme)
   disable_highlight = false # set to true to disable Highlight
   highlightjsVersion = "9.12.0"
-  highlightjsCDN = "//cdn.bootcss.com"
+  highlightjsCDN = "//cdnjs.cloudflare.com/ajax/libs"
   highlightjsLang = ["r", "yaml", "css"]
   highlightjsTheme = "github"
   MathJaxCDN = "//cdn.bootcss.com"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,18 +8,19 @@
       {{ $.Scratch.Set "jsFiles" false }}
     {{ end }}
 
-    {{ if (not .Params.disable_highlight) }}
-      {{ $highVer := .Site.Params.highlightjsVersion }}
-      {{ $highCDN := (.Site.Params.highlightjsCDN | default "//cdn.bootcss.com") }}
-      {{ if (not (eq $highVer "")) }}
-        <script src="{{ $highCDN }}/highlight.js/{{ $highVer }}/highlight.min.js"></script>
+    {{ if (and (not .Site.Params.disable_highlight) (not .Params.disable_highlight)) }}
+        {{ $highVersion := .Site.Params.highlightjsVersion | default "9.12.0" }}
+        {{ $highCDN := .Site.Params.highlightjsVersion | default "//cdn.bootcss.com" }}
+        <script src="{{ $highCDN }}/highlight.js/{{ $highVersion }}/highlight.min.js"></script>
+
         {{ $.Scratch.Set "highLangs" .Site.Params.highlightjsLang }}
         {{ range .Params.highlightjsLang }}{{ $.Scratch.Add "highLangs" . }}{{ end }}
         {{ range ($.Scratch.Get "highLangs") }}
-        <script src="{{ $highCDN }}/highlight.js/{{ $highVer }}/languages/{{ . }}.min.js"></script>{{ end }}
-        <script>hljs.configure({languages: []}); hljs.initHighlightingOnLoad();</script>
-      {{ end }}
+          <script src="{{ $highCDN }}/highlight.js/{{ $highVersion }}/languages/{{ . }}.min.js"></script>
+        {{ end }}
+        <script>hljs.initHighlightingOnLoad();</script>
     {{ end }}
+
     <!-- If the value "default" is passed into the param then we will first
      load the standard js files associated with the theme -->
     {{ if or (in ($.Scratch.Get "jsFiles") "default") (eq ($.Scratch.Get "jsFiles") false) }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -10,7 +10,7 @@
 
     {{ if (and (not .Site.Params.disable_highlight) (not .Params.disable_highlight)) }}
         {{ $highVersion := .Site.Params.highlightjsVersion | default "9.12.0" }}
-        {{ $highCDN := .Site.Params.highlightjsVersion | default "//cdn.bootcss.com" }}
+        {{ $highCDN := .Site.Params.highlightjsCDN | default "//cdnjs.cloudflare.com/ajax/libs" }}
         <script src="{{ $highCDN }}/highlight.js/{{ $highVersion }}/highlight.min.js"></script>
 
         {{ $.Scratch.Set "highLangs" .Site.Params.highlightjsLang }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -51,7 +51,6 @@
         <!-- If the value "default" is passed into the param then we will first
              load the standard css files associated with the theme -->
         {{ if or (in ($.Scratch.Get "cssFiles") "default") (eq ($.Scratch.Get "cssFiles") false) }}
-            <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/atom-one-light.min.css">
             <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Raleway:400,800,900|Source+Sans+Pro:400,700">
             <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
             <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.1.25/jquery.fancybox.min.css">
@@ -68,12 +67,12 @@
             {{ end }}
         {{ end }}
 
-{{ if (not .Params.disable_highlight) }}
-  {{ $highTheme := .Site.Params.highlightjsTheme }}
-    {{ with .Site.Params.highlightjsVersion }}
-    <link href='{{ $.Site.Params.highlightjsCDN | default "//cdn.bootcss.com" }}/highlight.js/{{ . }}/styles/{{ $highTheme }}.min.css' rel='stylesheet' type='text/css' />
-  {{ end }}
-{{ end }}
+        {{ if (and (not .Site.Params.disable_highlight) (not .Params.disable_highlight)) }}
+            {{ $highTheme := .Site.Params.highlightjsTheme | default "github" }}
+            {{ $highVersion := .Site.Params.highlightjsVersion | default "9.12.0" }}
+            {{ $highCDN := .Site.Params.highlightjsVersion | default "//cdn.bootcss.com" }}
+            <link href='{{ $highCDN }}/highlight.js/{{ $highVersion }}/styles/{{ $highTheme }}.min.css' rel='stylesheet' type='text/css' />
+        {{ end }}
 
       {{ template "_internal/google_analytics.html" . }}
     </head>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -70,7 +70,7 @@
         {{ if (and (not .Site.Params.disable_highlight) (not .Params.disable_highlight)) }}
             {{ $highTheme := .Site.Params.highlightjsTheme | default "github" }}
             {{ $highVersion := .Site.Params.highlightjsVersion | default "9.12.0" }}
-            {{ $highCDN := .Site.Params.highlightjsVersion | default "//cdn.bootcss.com" }}
+            {{ $highCDN := .Site.Params.highlightjsCDN | default "//cdnjs.cloudflare.com/ajax/libs" }}
             <link href='{{ $highCDN }}/highlight.js/{{ $highVersion }}/styles/{{ $highTheme }}.min.css' rel='stylesheet' type='text/css' />
         {{ end }}
 


### PR DESCRIPTION
## Description
Use default values of "github" for theme and 9.12.0 for version. Allow highlights to be disabled globally or per page.

## Motivation and Context
Closes #131.

## How Has This Been Tested?
Tested manually.

**Hugo Version:** 0.37.1

**Browser(s):** Chrome

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the [code style] of this project.
- [ ] My change requires a change to the [documentation].
- [ ] I have updated the documentation, including `theme.toml`, accordingly.
- [x] I have read the [Contributing Document].

[Code Style]: https://github.com/jpescador/hugo-future-imperfect/blob/master/.github/CONTRIBUTING.md#Style-Guide
[Contributing Document]: https://github.com/jpescador/hugo-future-imperfect/blob/master/.github/CONTRIBUTING.md
[Documentation]: https://github.com/jpescador/hugo-future-imperfect/wiki
