### PR TITLE
Add trailing slash to category links in blog posts

### DIFF
--- a/layouts/post/footer-category.html
+++ b/layouts/post/footer-category.html
@@ -6,7 +6,7 @@
             {{ if gt $categoriesLen 0 }}
                 <i class="fa fa-folder"></i>
                 {{ range $k, $v := .Params.categories }}
-                {{ $url := printf "categories/%s" (. | urlize | lower) }}
+                {{ $url := printf "categories/%s/" (. | urlize | lower) }}
                 <li><a class="article-category-link" href="{{ $url | absLangURL }}">{{ . }}</a></li>
                 {{ end }}
             {{ end }}


### PR DESCRIPTION
## Description
Currently, when rendering blog posts, the category URLs do not include a trailing slash. For example:
http://localhost/categories/banana
http://localhost/categories/apple

This fix simply corrects this:
http://localhost/categories/banana/
http://localhost/categories/apple/

The sidecar category links already include the trailing slash.

## Motivation and Context
* Prevents unnecessary redirect with NGinX
* Allows generally-available lambda@edge function to enable CloudFront with private S3 buckets to display index documents on subfolders. See https://aws.amazon.com/blogs/compute/implementing-default-directory-indexes-in-amazon-s3-backed-amazon-cloudfront-origins-using-lambdaedge/
* **Gives consistency with the category links rendered on the sidebar**

## How Has This Been Tested?
Locally, made change to theme, tested URLs render successfully. They do.

**Hugo Version:**
```
$ hugo version
Hugo Static Site Generator v0.46 linux/amd64 BuildDate: 2018-08-02T22:40:09+0200
```

**Browser(s):**
* Chrome
* Firefox

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [*] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the [code style] of this project.
- [ ] My change requires a change to the [documentation].
- [ ] I have updated the documentation, including `theme.toml`, accordingly.
- [*] I have read the [Contributing Document].

I don't think many of the boxes above are relevant to this change. No documentation required.

[Code Style]: https://github.com/jpescador/hugo-future-imperfect/blob/master/.github/CONTRIBUTING.md#Style-Guide
[Contributing Document]: https://github.com/jpescador/hugo-future-imperfect/blob/master/.github/CONTRIBUTING.md
[Documentation]: https://github.com/jpescador/hugo-future-imperfect/wiki
