### PR TITLE
Fix featured `alt` text not being used.

### DIFF
--- a/layouts/partials/img-path.html
+++ b/layouts/partials/img-path.html
@@ -3,7 +3,6 @@
 
      Set the path depending on the value passed through
 
-     if path is title then it will use the LinkTitle from the Page variable
      if path is date then it will format the directory to year/date i.e. 2006/01
      Note: path will be concatenated to the root directory, img
 
@@ -11,8 +10,6 @@
 -->
 
 {{ $src := $.Scratch.Get "path" }}
-{{ $alt := $.Scratch.Get "featuredalt" }}
-{{ $img := $.Scratch.Get "featured" }}
 {{ $structType := $.Scratch.Get "structType" }}
 
 {{ if eq $src "date" }}

--- a/layouts/post/featured.html
+++ b/layouts/post/featured.html
@@ -5,11 +5,9 @@
         {{ $.Scratch.Set "structType" "page" }}
         {{ partial "img-path" . }}
         {{ $path := $.Scratch.Get "path" }}
-        {{ $alt := $.Scratch.Get "alt" }}
-        {{ $img := $.Scratch.Get "img" }}
 
         <a href="{{ .RelPermalink }}" class="image featured">
-            <img src="{{ $path | relURL }}/{{ .Params.featured }}" alt="{{ $alt }}">
+            <img src="{{ $path | relURL }}/{{ .Params.featured }}" alt="{{ .Params.featuredalt }}">
         </a>
     {{ end }}
 {{ end }}


### PR DESCRIPTION
<!--- Prerequisites -->
<!--- I am running the latest version of [Hugo](https://github.com/gohugoio/hugo/releases) -->
<!--- I am using the latest version of [Hugo-Future-Imperfect](https://github.com/jpescador/hugo-future-imperfect/releases) -->
<!--- I checked the [issues](https://github.com/jpescador/hugo-future-imperfect/issues?utf8=%E2%9C%93&q=is%3Aissue) to make sure that this feature has not been rejected before -->
<!--- I checked the [pull requests](https://github.com/jpescador/hugo-future-imperfect/pulls?utf8=%E2%9C%93&q=is%3Apr) to make sure that this feature is not already being developed -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix featured `alt` text not being used.

Also:
- Remove comment about old `title` option for image paths
- Remove unused variables

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here with "Closes #XXX" -->

The featured image `alt` text is not populated even though `featuredalt` has a value in my blog posts.

Also, the extra variables are confusing, as is the comment about `title` being an option for image path.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested with my (very basic) site and with the example site that's bundled with the hugo-future-imperfect theme.

Someone with more Hugo experience (and especially with this template) will hopefully double-check with their site.

**Hugo Version:**

Hugo Static Site Generator v0.55.5-A83256B9 windows/amd64 BuildDate: 2019-05-02T13:04:07Z

**Browser(s):**

Firefox

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the [code style] of this project.
- [ ] My change requires a change to the [documentation].
- [ ] I have updated the documentation, including `theme.toml`, accordingly.
- [x] I have read the [Contributing Document].

[Code Style]: https://github.com/jpescador/hugo-future-imperfect/blob/master/.github/CONTRIBUTING.md#Style-Guide
[Contributing Document]: https://github.com/jpescador/hugo-future-imperfect/blob/master/.github/CONTRIBUTING.md
[Documentation]: https://github.com/jpescador/hugo-future-imperfect/wiki
