### PR TITLE
Fix disable_highlight option

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,5 @@
+baseURL = "https://example.com/"
+
+[module]
+[module.hugoVersion]
+min = "0.96.0"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,7 +8,7 @@
       {{ $.Scratch.Set "jsFiles" false }}
     {{ end }}
 
-    {{ if (not .Params.disable_highlight) }}
+    {{ if (not .Site.Params.disable_highlight) }}
       {{ $highVer := .Site.Params.highlightjsVersion }}
       {{ $highCDN := (.Site.Params.highlightjsCDN | default "//cdn.bootcss.com") }}
       {{ if (not (eq $highVer "")) }}
@@ -39,8 +39,10 @@
       {{ end }}
     {{ end }}
 
-    <!-- This is called by default since this theme uses highlight.js -->
-    <script>hljs.initHighlightingOnLoad();</script>
-      {{ partial "footer_mathjax" . }}
+    {{ if (not .Site.Params.disable_highlight) }}
+      <!-- This is called by default since this theme uses highlight.js -->
+      <script>hljs.initHighlightingOnLoad();</script>
+    {{ end }}
+    {{ partial "footer_mathjax" . }}
   </body>
 </html>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -68,7 +68,7 @@
             {{ end }}
         {{ end }}
 
-{{ if (not .Params.disable_highlight) }}
+{{ if (not .Site.Params.disable_highlight) }}
   {{ $highTheme := .Site.Params.highlightjsTheme }}
     {{ with .Site.Params.highlightjsVersion }}
     <link href='{{ $.Site.Params.highlightjsCDN | default "//cdn.bootcss.com" }}/highlight.js/{{ . }}/styles/{{ $highTheme }}.min.css' rel='stylesheet' type='text/css' />

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -19,7 +19,7 @@
 
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        {{ .Hugo.Generator }}
+        {{ hugo.Generator }}
         {{ partial "favicon" . }}
 
         {{ with .Params.author }}
@@ -40,7 +40,6 @@
         <meta property="og:image:width" content="512">
         <meta property="og:image:height" content="512">
         {{ template "_internal/schema.html" . }}
-        {{ template "_internal/google_news.html" . }}
 
         {{ if isset .Site.Params "customcss" }}
             {{ $.Scratch.Set "cssFiles" .Site.Params.customCSS }}


### PR DESCRIPTION
Fix the disable_highlight option, as it currently doesn't work

## Description
Correctly check .Site params

## Motivation and Context
It fixes the option, as it currently doesn't work

## How Has This Been Tested?
I set disable_highlight = true, and checked that the Javascript is no longer included

**Hugo Version:**

**Browser(s):**

## Screenshots (if appropriate):

## Types of changes

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the [code style] of this project.
- [ ] My change requires a change to the [documentation].
- [ ] I have updated the documentation, including `theme.toml`, accordingly.
- [x] I have read the [Contributing Document].

[Code Style]: https://github.com/jpescador/hugo-future-imperfect/blob/master/.github/CONTRIBUTING.md#Style-Guide
[Contributing Document]: https://github.com/jpescador/hugo-future-imperfect/blob/master/.github/CONTRIBUTING.md
[Documentation]: https://github.com/jpescador/hugo-future-imperfect/wiki
